### PR TITLE
Add Spock unit tests for Jenkins helper functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.gradle/
+build/

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,17 @@
+plugins {
+    id 'groovy'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation localGroovy()
+    testImplementation 'org.spockframework:spock-core:2.3-groovy-3.0'
+    testImplementation 'com.lesfurets:jenkins-pipeline-unit:1.1'
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'jenkins_integration'

--- a/src/main/groovy/com/example/JenkinsHelpers.groovy
+++ b/src/main/groovy/com/example/JenkinsHelpers.groovy
@@ -1,0 +1,14 @@
+package com.example
+
+class JenkinsHelpers {
+    static String filterId(String id) {
+        if (id == null) return ''
+        return id.replaceAll(/[^0-9]/, '')
+    }
+
+    static String getTaskId(String branch) {
+        if (branch == null) return ''
+        def matcher = (branch =~ /([A-Z]+-\d+)/)
+        return matcher.find() ? matcher.group(1) : ''
+    }
+}

--- a/src/test/groovy/com/example/JenkinsHelpersSpec.groovy
+++ b/src/test/groovy/com/example/JenkinsHelpersSpec.groovy
@@ -1,0 +1,29 @@
+package com.example
+
+import spock.lang.Specification
+
+class JenkinsHelpersSpec extends Specification {
+    def "filterId should extract digits"() {
+        expect:
+        JenkinsHelpers.filterId(input) == expected
+
+        where:
+        input         || expected
+        'ABC-123'     || '123'
+        'id_45-67x'   || '4567'
+        ''            || ''
+        null          || ''
+    }
+
+    def "getTaskId should extract task id from branch"() {
+        expect:
+        JenkinsHelpers.getTaskId(branch) == expected
+
+        where:
+        branch                              || expected
+        'feature/TASK-123-add-tests'        || 'TASK-123'
+        'hotfix/BUG-987'                    || 'BUG-987'
+        'master'                            || ''
+        null                                || ''
+    }
+}


### PR DESCRIPTION
## Summary
- set up Groovy/Spock Gradle build
- implement Jenkins helper library
- add Spock tests for `filterId` and `getTaskId`
- ignore build artifacts

## Testing
- `gradle test --no-daemon --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_6866d992bf44832ca680c5721a5acf86